### PR TITLE
Allow format MM:SS to show hours after the first 60 minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This simple integration `<cd-timer></cd-timer>` will start the timer with the de
 - `format`: Display timer count in predefined format. Default: 'user' or 'default'.
   - `default`: Display like `0d 0h 0m 0s`.
   - `hms`: Display like `HH:MM:SS`.
-  - `ms`: Display like `MM:SS`.
+  - `ms`: Display like `[HH]:MM:SS`. Hours are shown just when the timer pass the first 60 minutes.
   - `intelli`: Display in condensed format:
     - only seconds: 25s
     - minutes and seconds: 02min 12s

--- a/angular.json
+++ b/angular.json
@@ -1,5 +1,8 @@
 {
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "cli": {
+    "analytics": false
+  },
   "version": 1,
   "newProjectRoot": "projects",
   "projects": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,7 +131,8 @@
         },
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "ansi-styles": {
@@ -724,7 +725,8 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "ansi-styles": {
@@ -3400,7 +3402,8 @@
         },
         "minimist": {
           "version": "1.2.5",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         },
         "semver": {
@@ -9279,7 +9282,8 @@
         },
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "ansi-styles": {
@@ -11890,7 +11894,8 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "ansi-styles": {
@@ -12668,7 +12673,8 @@
         },
         "minimist": {
           "version": "1.2.5",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         },
         "postcss": {
@@ -16193,7 +16199,8 @@
         },
         "minimist": {
           "version": "1.2.5",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }

--- a/projects/angular-cd-timer/README.md
+++ b/projects/angular-cd-timer/README.md
@@ -60,6 +60,7 @@ This simple integration `<cd-timer></cd-timer>` will start the timer with the de
 - `format`: Display timer count in predefined format. Default: 'user' or 'default'.
   - `default`: Display like `0d 0h 0m 0s`.
   - `hms`: Display like `HH:MM:SS`.
+  - `ms`: Display like `[HH]:MM:SS`. Hours are shown just when the timer pass the first 60 minutes.
   - `intelli`: Display in condensed format:
     - only seconds: 25s
     - minutes and seconds: 02min 12s

--- a/projects/angular-cd-timer/src/lib/angular-cd-timer.component.ts
+++ b/projects/angular-cd-timer/src/lib/angular-cd-timer.component.ts
@@ -179,6 +179,9 @@ export class CdTimerComponent implements AfterViewInit, OnDestroy {
     } else if (this.format === 'ms') {
       // ms presentation
       outputText = '';
+      if(this.hours>0) {
+        outputText = this.hours.toString().padStart(2, '0') + ':';
+      }
       outputText += this.minutes.toString().padStart(2, '0') + ':';
       outputText += this.seconds.toString().padStart(2, '0');
     } else {


### PR DESCRIPTION
Update documentation and allow the format MM:SS to show the hours just when hours is more than 0.